### PR TITLE
removed free_y on maps to keep aspect ratio

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,3 @@
+^.*\.Rproj$
+^\.Rproj\.user$
+R/OuterHull.R

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.Rproj.user
+.Rhistory
+.RData

--- a/R/MapGraphs.r
+++ b/R/MapGraphs.r
@@ -169,10 +169,9 @@ RankMaps <- function(pl, p, mapDF, att){
 			colour=att[[p]]$active.border.color, 
 			size=att[[p]]$active.border.size/2, 
 			data=subset(mapDF, hole==0)) + 				
-		facet_grid(pGrp~., scales="free_y", space="free") +
+		facet_grid(pGrp~., space="free") +
 		scale_fill_manual(values=c(att$colors), guide='none') +
 		coord_equal() 
-
 
 	  #################################
 	  #################################
@@ -190,7 +189,7 @@ RankMaps <- function(pl, p, mapDF, att){
 			geom_polygon(fill='white', colour='white', data=mapDF.median) + 
 				geom_text(aes(x=textx, y=texty, label=tmp.label, hjust=.5, vjust=.4),
 						colour=att$median.text.color, size=5*att$median.text.size, data=mapDF.median) +
-				facet_grid(pGrp~., scales="free_y", space="free")
+				facet_grid(pGrp~., space="free")
 
 	  #################################
 	  #################################
@@ -258,8 +257,7 @@ RankMaps <- function(pl, p, mapDF, att){
 
 	pl <- pl + theme(panel.margin = unit(0, "lines"))
 
-
-	pl 
+	pl
 
 }
 
@@ -276,7 +274,7 @@ CatMaps <- function(pl, p, mapDF, att){
 		geom_polygon(fill=att$map.color, colour='black', data=subset(mapDF, hole==0)) + 				
 		geom_polygon(fill='white', colour='black', data=subset(mapDF, hole==1)) +
 		geom_polygon(fill='transparent', colour='black', data=subset(transform(mapDF, pGrp=NULL), hole==1)) +
-		facet_grid(pGrp~., scales="free_y", space="free") +
+		facet_grid(pGrp~., space="free") +
 		coord_equal() 
 
 


### PR DESCRIPTION
The argument `scales = 'free_y'` in the `RankMaps` function was removing the effect of `coord_equal()` in the map facets.  This caused the aspect ratio of the maps to change if the plot window was resized manually.  This pull request removes the scales argument from the function to keep the map aspect ratios.  

Feel free to ignore if you don't want to add this feature.