### PR TITLE
Remove free y-scales on MapGraphs

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,3 @@
+^.*\.Rproj$
+^\.Rproj\.user$
+R/OuterHull.R

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.Rproj.user
+.Rhistory
+.RData

--- a/R/CreateMapTable.r
+++ b/R/CreateMapTable.r
@@ -11,7 +11,7 @@ create_map_table <- function (tmp.map, IDcolumn = NA, poly.thresh=.0001)
         lPoly[[i]] <- lapply(1:length(tmp@Polygons), function(j) cbind(i, 
             j, tmp@Polygons[[j]]@labpt[1], tmp@Polygons[[j]]@labpt[2], 
             tmp@Polygons[[j]]@coords, tmp@Polygons[[j]]@hole, 
-            tmp@Polygons[[j]]@area))
+            tmp@Polygons[[j]]@area,tmp@plotOrder[[j]]))
 	
 	  tot.area <- tot.area + tmp@area
     }
@@ -34,7 +34,7 @@ create_map_table <- function (tmp.map, IDcolumn = NA, poly.thresh=.0001)
 
 
     dPoly2 <- data.frame(tmp.map@data$ID[dPoly[, 1]], dPoly)
-    names(dPoly2) <- c("ID", "region", "poly", "lab.x", "lab.y", "coordsx", "coordsy", "hole", "area")
+    names(dPoly2) <- c("ID", "region", "poly", "lab.x", "lab.y", "coordsx", "coordsy", "hole", "area", "plotorder")
     dPoly2 <- transform(dPoly2, poly = (region - 1) * max(dPoly2$poly) + poly)
 
     tholes <- unique(subset(dPoly2, hole == 1)[, c("poly", "lab.x", "lab.y", "area")])

--- a/R/MapGraphs.r
+++ b/R/MapGraphs.r
@@ -1,5 +1,3 @@
-# TEST 002
-
 RankMaps <- function(pl, p, mapDF, att){
 	# att=a
 	bgcolor 	<- ifelse(!is.na(att[[p]]$panel.bgcolor), att[[p]]$panel.bgcolor, 'white')
@@ -336,5 +334,8 @@ CatMaps <- function(pl, p, mapDF, att){
 	pl
 
 }
+
+
+
 
 

--- a/R/MapGraphs.r
+++ b/R/MapGraphs.r
@@ -169,7 +169,7 @@ RankMaps <- function(pl, p, mapDF, att){
 			colour=att[[p]]$active.border.color, 
 			size=att[[p]]$active.border.size/2, 
 			data=subset(mapDF, hole==0)) + 				
-		facet_grid(pGrp~., scales="free_y", space="free") +
+		facet_grid(pGrp~., space="free") +
 		scale_fill_manual(values=c(att$colors), guide='none') +
 		coord_equal() 
 
@@ -190,7 +190,7 @@ RankMaps <- function(pl, p, mapDF, att){
 			geom_polygon(fill='white', colour='white', data=mapDF.median) + 
 				geom_text(aes(x=textx, y=texty, label=tmp.label, hjust=.5, vjust=.4),
 						colour=att$median.text.color, size=5*att$median.text.size, data=mapDF.median) +
-				facet_grid(pGrp~., scales="free_y", space="free")
+				facet_grid(pGrp~., space="free")
 
 	  #################################
 	  #################################
@@ -276,7 +276,7 @@ CatMaps <- function(pl, p, mapDF, att){
 		geom_polygon(fill=att$map.color, colour='black', data=subset(mapDF, hole==0)) + 				
 		geom_polygon(fill='white', colour='black', data=subset(mapDF, hole==1)) +
 		geom_polygon(fill='transparent', colour='black', data=subset(transform(mapDF, pGrp=NULL), hole==1)) +
-		facet_grid(pGrp~., scales="free_y", space="free") +
+		facet_grid(pGrp~., space="free") +
 		coord_equal() 
 
 


### PR DESCRIPTION
This was removing any effect of coord_equal on the maps.  The aspect ratios should now be maintained if the plots are resized manually.