### PR TITLE
more flexible color options

### DIFF
--- a/R/mmGroupedPlot.r
+++ b/R/mmGroupedPlot.r
@@ -43,6 +43,9 @@ mmgroupedplot <- function(stat.data, map.data, 		# Required -- statistical data;
 dStats <- stat.data
 dMap <- map.data
 
+# create continous color vecor based on cat
+ncol <- length(unique(stat.data[, cat]))
+colors <- colorRampPalette(colors)(ncol)
 
 tPlot.header=plot.header
 iPlot.header.size=plot.header.size

--- a/R/mmPlot.r
+++ b/R/mmPlot.r
@@ -17,7 +17,6 @@ mmplot <- function(stat.data, map.data=NULL, 	# Required -- statistical data; ma
   median.text.color='black',
   median.text.size=1,
   median.text.label='Median',
-	
   colors=brewer.pal(max(grouping), "Spectral"),	
 
   ## These 3 are legacy arguements that should now 
@@ -55,7 +54,8 @@ dStats <- stat.data
 dMap <- map.data
 
 
-colors=colors[1:max(grouping)]	# errors can occur with a color list that is too long so we truncate 
+colors = colorRampPalette(colors)(grouping)
+# colors=colors[1:max(grouping)]	# errors can occur with a color list that is too long so we truncate 
 						 #	it to only the number of colors needed for this plot
 if(median.row) colors <- c(colors, median.color) # we add a color to be the color of the median polygon
 						 # 	this should probably be user specified in the future

--- a/man/mmplot.Rd
+++ b/man/mmplot.Rd
@@ -111,9 +111,11 @@ lmgroupedplot(stat.data, map.data, panel.types, panel.data, map.link=NULL,
   category column within stats table for a categorization type lmplot.
   }
   \item{colors}{
-  a vector of colors for each perceptual group.  The default is
+  a vector of colors for the perceptual groups.  The default is
   brewer.pal(max(grouping), 'Spectral') for lmplot and brewer.pal(10,
-  'Spectral') for lmgroupedplot).
+  'Spectral') for lmgroupedplot).  The colors are passed to
+  \code{\link[grDevices]{colorRampPalette}} to create a continuous color 
+  vector equal in length to the groupings. 
   }
   \item{map.color}{
   the color to fill in previously displayed polygons.


### PR DESCRIPTION
I modified the way mmplot and mmgroupedplot handle the optional `colors` argument.  Basically, the new version passes the argument to colorRampPalette to create a continuous vector for each perceptual group.  This eliminates the need to supply a color argument that has the same length as the grouping argument.  See the examples below... as always, these are my ideas open for discussion so feel free to comment or reject the PR.

Some examples:

```r
library(micromap)

# illustrate color assigment with mmplot

data("edPov")

data("USstates")

statePolys <- create_map_table(USstates, 'ST')

# two color spectrum
mmplot(stat.data=edPov,
  map.data=statePolys,
  panel.types=c('labels', 'dot', 'dot','map'),
  panel.data=list('state','pov','ed', NA),
  ord.by='pov',   
  colors = c('red', 'blue'),     
  grouping=5, median.row=T,
  map.link=c('StateAb','ID'))

# one color with NA values (similar behavior as the previous version)
mmplot(stat.data=edPov,
  map.data=statePolys,
  panel.types=c('labels', 'dot', 'dot','map'),
  panel.data=list('state','pov','ed', NA),
  ord.by='pov',   
  colors = c('red', NA, NA, NA, NA),     
  grouping=5, median.row=T,
  map.link=c('StateAb','ID'))

# a brewer.pal color Spectrum
mmplot(stat.data=edPov,
  map.data=statePolys,
  panel.types=c('labels', 'dot', 'dot','map'),
  panel.data=list('state','pov','ed', NA),
  ord.by='pov',   
  colors = brewer.pal(11, 'PiYG'),     
  grouping=5, median.row=T,
  map.link=c('StateAb','ID'))

##
# same story for mmgroupedpot

data('vegCov')
data('WSA3')
print(vegCov)
print(WSA3@data)

wsa.polys <- create_map_table(WSA3)
head(wsa.polys)

# create a national polygon area based on the 9 NARS reporting regions
national.polys <-subset(wsa.polys, hole==0 & plug==0)
national.polys <- transform(national.polys, ID='National', region=4, poly=region*1000 + poly)
head(national.polys)

wsa.polys <- rbind(wsa.polys, national.polys)

# missing colors
mmgroupedplot(stat.data=vegCov,
  map.data=wsa.polys,
  colors = c('blue', 'green', NA), 
  panel.types=c('map', 'labels', 'bar_cl', 'bar_cl'),
  panel.data=list(NA,'Category',
    list('Estimate.P','LCB95Pct.P','UCB95Pct.P'),
    list('Estimate.U','LCB95Pct.U','UCB95Pct.U')),
  grp.by='Subpopulation',
  cat='Category',
  map.link=c('Subpopulation', 'ID'))

# two color spectrum
mmgroupedplot(stat.data=vegCov,
  map.data=wsa.polys,
  colors = c('blue', 'red'), 
  panel.types=c('map', 'labels', 'bar_cl', 'bar_cl'),
  panel.data=list(NA,'Category',
    list('Estimate.P','LCB95Pct.P','UCB95Pct.P'),
    list('Estimate.U','LCB95Pct.U','UCB95Pct.U')),
  grp.by='Subpopulation',
  cat='Category',
  map.link=c('Subpopulation', 'ID'))
```