### PR TITLE
some minor changes to contributing instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Please use this workflow for contributing to the micromap package.
 
 * Fork this repo to your Github account
 * Clone your version on your account down to your machine from your account, e.g,. `git clone https://github.com/<yourgithubusername>/R-micromap-package-development.git`
-* Make sure to track progress upstream (i.e., on our version of `R-micromap-package-development` at `USEPA/R-micromap-package-development`) by doing `git remote add upstream https://github.com/USEPA/R-micromap-package-development.git`. Before making changes make sure to pull changes in from upstream by doing either `git fetch upstream` then merge later or `git pull upstream` to fetch and merge in one step.
+* Make sure to track progress upstream (i.e., on our version of `R-micromap-package-development` at `USEPA/R-micromap-package-development`) by doing `git remote add upstream https://github.com/USEPA/R-micromap-package-development.git`. Before making changes make sure to pull changes in from the development branch upstream by doing either `git fetch upstream development` then merge later or `git pull upstream development` to fetch and merge in one step.
 * Checkout the development branch on your local machine with `git checkout development`.  The master branch will be stable until a new version is pushed to CRAN.
 * Make any changes or additions to the development branch.  If you are adding a new function, or changing functionality of a function, include new tests, and make sure those pass before submitting the pull request (PR).
 * Push up to your account using `git push origin development`.


### PR DESCRIPTION
This is just some changes to the text in the contributing guide.  I made the same changes in the development branch but wanted to reconcile in the master so it shows up on the main GitHub page for the repository.  